### PR TITLE
Add dataloader for UDA and new CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python fedd3_main.py -nc 500 \
 
 - `--sys-n_client` `-nc`: Number of clients
 - `--sys-n_local_class` `-ck`: Number of classes in each client
-- `--sys-dataset` `-ds`: Dataset name (one of "MNIST", "CIFAR-10", "FashionMnist", "SVHN", or "CIFAR100")
+- `--sys-dataset` `-ds`: Dataset name (one of "MNIST", "CIFAR-10", "FashionMnist", "SVHN", or "CIFAR100", "OFFICEHOME")
 - `--sys-model` `-md`: Model name (e.g., "LeNet" for MNIST, "AlexCifarNet" for CIFAR-10, "CNN" for CIFAR-100)
 - `--sys-i_seed` `-is`: Seed used in experiments
 - `--sys-res_root` `-rr`: Root directory of results
@@ -96,6 +96,11 @@ python fedd3_main.py -nc 500 \
 * **Examples II** Run FedD3 on Non-IID MNIST with 500 clients:
 `python fedd3_main.py -nc 500 -ck 2 -ds 'MNIST' -md 'LeNet' -is 0 -rr 'results' 
 -sne 500 -sbs 50 -slr 0.001 -smt 0.9 -snw 1 -cis 'kip_distill' -cnd 2 -cil 0.004 -cib 10 -cie 3000 -cit 0.999`
+* **Example III** Run FedD3 for Unsupervised Domain Adaptation on OfficeHome:
+`python fedd3_main.py -nc 3 -ck 65 -ds 'OFFICEHOME' -md 'ResNet18' -is 0 -rr 'results' 
+-sne 500 -sbs 32 -slr 0.001 -smt 0.9 -snw 1 
+-cis 'kip_distill' -cnd 10 -cil 0.004 -cib 10 -cie 3000 -cit 0.999 
+-dd '/path/to/domain_txts' -td 'Real_World.txt'`
   
 
 * **Results**
@@ -128,7 +133,7 @@ python baselines_main.py -nc 10 \
 
 - `--sys-n_client` `-nc`: Number of clients
 - `--sys-n_local_class` `-ck`: Number of classes in each client
-- `--sys-dataset` `-ds`: Dataset name (one of "MNIST", "CIFAR10", "FashionMnist", "SVHN", or "CIFAR100")
+- `--sys-dataset` `-ds`: Dataset name (one of "MNIST", "CIFAR10", "FashionMnist", "SVHN", or "CIFAR100", "OFFICEHOME")
 - `--sys-model` `-md`: Model name
 - `--sys-i_seed` `-is`: Seed used in experiments
 - `--sys-res_root` `-rr`: Root directory of the results

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ python fedd3_main.py -nc 500 \
 `python fedd3_main.py -nc 500 -ck 2 -ds 'MNIST' -md 'LeNet' -is 0 -rr 'results' 
 -sne 500 -sbs 50 -slr 0.001 -smt 0.9 -snw 1 -cis 'kip_distill' -cnd 2 -cil 0.004 -cib 10 -cie 3000 -cit 0.999`
 * **Example III** Run FedD3 for Unsupervised Domain Adaptation on OfficeHome:
-`python fedd3_main.py -nc 3 -ck 65 -ds 'OFFICEHOME' -md 'ResNet18' -is 0 -rr 'results' 
--sne 500 -sbs 32 -slr 0.001 -smt 0.9 -snw 1 
--cis 'kip_distill' -cnd 10 -cil 0.004 -cib 10 -cie 3000 -cit 0.999 
+`python fedd3_main.py -nc 3 -ck 65 -ds 'OFFICEHOME' -md 'ResNet18' -is 0 -rr 'results'
+-sne 500 -sbs 32 -slr 0.001 -smt 0.9 -snw 1
+-cis 'kip_distill' -cnd 65 -cil 0.004 -cib 10 -cie 3000 -cit 0.999
 -dd '/path/to/domain_txts' -td 'Real_World.txt'`
   
 

--- a/baselines_main.py
+++ b/baselines_main.py
@@ -17,6 +17,7 @@ from fed_baselines.server_fednova import FedNovaServer
 
 from postprocessing.recorder import Recorder
 from preprocessing.baselines_dataloader import divide_data
+from preprocessing.uda_dataloader import divide_domain_data
 from utils.models import *
 
 json_types = (list, dict, str, int, float, bool, type(None))
@@ -57,6 +58,8 @@ def fed_args():
     parser.add_argument('-cie', '--client-instance_n_epoch', type=int, required=True, help='Number of local training epochs in clients')
     parser.add_argument('-sim', '--client-instance_momentum', type=float, required=True, help='Momentum of local training in clients')
     parser.add_argument('-sin', '--client-instance_n_worker', type=int, required=True, help='Number of workers in the server')
+    parser.add_argument('-dd', '--domain-dir', type=str, default=None, help='Directory of domain txt files for UDA')
+    parser.add_argument('-td', '--target-domain', type=str, default=None, help='Name of target domain txt file without extension')
 
     args = parser.parse_args()
     return args
@@ -71,7 +74,7 @@ def fed_run():
     algo_list = ["FedAvg", "SCAFFOLD", "FedProx", "FedNova"]
     assert args.client_instance in algo_list, "The federated learning algorithm is not supported"
 
-    dataset_list = ['MNIST', 'CIFAR10', 'FashionMNIST', 'SVHN', 'CIFAR100']
+    dataset_list = ['MNIST', 'CIFAR10', 'FashionMNIST', 'SVHN', 'CIFAR100', 'OFFICEHOME']
     assert args.sys_dataset in dataset_list, "The dataset is not supported"
 
     model_list = ["LeNet", 'AlexCifarNet', "ResNet18", "ResNet34", "ResNet50", "ResNet101", "ResNet152", "CNN"]
@@ -84,8 +87,18 @@ def fed_run():
     client_dict = {}
     recorder = Recorder()
 
-    trainset_config, testset = divide_data(num_client=args.sys_n_client, num_local_class=args.sys_n_local_class, dataset_name=args.sys_dataset,
-                                           i_seed=args.sys_i_seed)
+    if args.domain_dir:
+        assert args.target_domain is not None, "Target domain must be specified when using domain-dir"
+        all_txts = [os.path.join(args.domain_dir, f) for f in os.listdir(args.domain_dir) if f.endswith('.txt')]
+        target_txt = os.path.join(args.domain_dir, args.target_domain)
+        if not target_txt.endswith('.txt'):
+            target_txt += '.txt'
+        source_txts = [x for x in all_txts if os.path.basename(x) != os.path.basename(target_txt)]
+        args.sys_n_client = len(source_txts)
+        trainset_config, testset = divide_domain_data(source_txts, target_txt)
+    else:
+        trainset_config, testset = divide_data(num_client=args.sys_n_client, num_local_class=args.sys_n_local_class, dataset_name=args.sys_dataset,
+                                               i_seed=args.sys_i_seed)
     max_acc = 0
     # Initialize the clients w.r.t. the federated learning algorithms and the specific federated settings
     for client_id in trainset_config['users']:

--- a/fedd3/fedd3_client.py
+++ b/fedd3/fedd3_client.py
@@ -99,6 +99,12 @@ class FedClient(object):
               "starts distilling %d " % len(self._train_data['y']) +
               "data points into %s data points" % k)
 
+        n_classes = len(torch.unique(self._train_data['y']))
+        if k % n_classes != 0:
+            raise ValueError(
+                f"Number of classes {n_classes} must divide k={k}. "
+                "Please choose --client-n_dd accordingly.")
+
         params = distill_kip_unit(
             np.array(self._train_data['x'].squeeze(1).permute(0, 2, 3, 1)),
             np.array(self._train_data['y'].squeeze()), num_dd_epoch=num_train_steps, seed=seed, k=k, lr=lr,

--- a/fedd3_main.py
+++ b/fedd3_main.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import torch
+import os
 import random
 import numpy as np
 import argparse
 from preprocessing.fedd3_dataloader import divide_data
+from preprocessing.uda_dataloader import divide_domain_data
 from fedd3.fedd3_client import FedClient
 from fedd3.fedd3_server import FedServer
 
@@ -36,6 +38,8 @@ def fed_args():
     parser.add_argument('-cib', '--client-instance_bs', type=int, required=True, help='Batch size in clients')
     parser.add_argument('-cie', '--client-instance_max_n_epoch', type=int, required=True, help='Maximal number of epochs in clients')
     parser.add_argument('-cit', '--client-instance_threshold', type=float, required=True, help='Accuracy threshold for dataset distillation in clients')
+    parser.add_argument('-dd', '--domain-dir', type=str, default=None, help='Directory of domain txt files for UDA')
+    parser.add_argument('-td', '--target-domain', type=str, default=None, help='Name of target domain txt file without extension')
 
     args = parser.parse_args()
     return args
@@ -50,7 +54,7 @@ def main():
     mode_list = ["all_select", "kip_distill", "gmm", "dbscan"]
     assert args.client_instance in mode_list, "The mode is not supported"
 
-    dataset_list = ['MNIST', 'CIFAR10', 'FashionMNIST', 'SVHN', 'CIFAR100']
+    dataset_list = ['MNIST', 'CIFAR10', 'FashionMNIST', 'SVHN', 'CIFAR100', 'OFFICEHOME']
     assert args.sys_dataset in dataset_list, "The dataset is not supported"
 
     model_list = ["LeNet", 'AlexCifarNet', 'CNN', 'ResNet18', 'ResNet50', "ResNet152"]
@@ -74,11 +78,21 @@ def main():
     client_dict = {}
     distill_dataset = {'x': [], 'y': []}
 
-    # Distribute the dataset into each client with respect to number of local classes
-    trainset_config, test_iid_data = divide_data(num_client=args.sys_n_client,
-                                                 num_local_class=args.sys_n_local_class,
-                                                 dataset_name=args.sys_dataset,
-                                                 i_seed=args.sys_i_seed)
+    # Distribute the dataset into each client
+    if args.domain_dir:
+        assert args.target_domain is not None, "Target domain must be specified when using domain-dir"
+        all_txts = [os.path.join(args.domain_dir, f) for f in os.listdir(args.domain_dir) if f.endswith('.txt')]
+        target_txt = os.path.join(args.domain_dir, args.target_domain)
+        if not target_txt.endswith('.txt'):
+            target_txt += '.txt'
+        source_txts = [x for x in all_txts if os.path.basename(x) != os.path.basename(target_txt)]
+        args.sys_n_client = len(source_txts)
+        trainset_config, test_iid_data = divide_domain_data(source_txts, target_txt)
+    else:
+        trainset_config, test_iid_data = divide_data(num_client=args.sys_n_client,
+                                                     num_local_class=args.sys_n_local_class,
+                                                     dataset_name=args.sys_dataset,
+                                                     i_seed=args.sys_i_seed)
 
     # Initialize each client and distill the local data.
     # (Since it is one-shot, initialization does not have to do separately)

--- a/preprocessing/uda_dataloader.py
+++ b/preprocessing/uda_dataloader.py
@@ -1,0 +1,53 @@
+import os
+from PIL import Image
+import torch
+from torchvision import transforms
+from tqdm import tqdm
+
+
+def _load_txt_dataset(txt_file, image_size=224, root=""):
+    """Load images and labels listed in a text file.
+
+    Each line in the text file should contain an image path and the
+    corresponding integer label separated by whitespace.
+    Paths are considered relative to ``root`` if provided.
+    Returns tensors ``data`` and ``targets`` suitable for FedD3 loaders.
+    """
+    transform = transforms.Compose([
+        transforms.Resize((image_size, image_size)),
+        transforms.ToTensor(),
+    ])
+    images = []
+    labels = []
+    with open(txt_file, "r") as f:
+        for line in tqdm(f.readlines(), desc=f"loading {os.path.basename(txt_file)}"):
+            path, label = line.strip().split()
+            path = os.path.join(root, path)
+            img = Image.open(path).convert("RGB")
+            img = transform(img)
+            images.append(img)
+            labels.append(int(label))
+    data = torch.stack(images)
+    targets = torch.tensor(labels)
+    return data, targets
+
+
+def divide_domain_data(source_txts, target_txt, image_size=224, root=""):
+    """Prepare federated splits for unsupervised domain adaptation.
+
+    ``source_txts`` should be a list of domain text files used as sources.
+    ``target_txt`` specifies the domain used for testing.
+    Each source domain corresponds to a client containing all its samples.
+    """
+    trainset_config = {"users": [], "user_data": {}, "num_samples": []}
+
+    for idx, txt in enumerate(source_txts):
+        data, targets = _load_txt_dataset(txt, image_size=image_size, root=root)
+        user = f"f_{idx:05d}"
+        trainset_config["users"].append(user)
+        trainset_config["user_data"][user] = {"x": data, "y": targets}
+        trainset_config["num_samples"].append(len(targets))
+
+    test_x, test_y = _load_txt_dataset(target_txt, image_size=image_size, root=root)
+    test_data = {"x": test_x, "y": test_y}
+    return trainset_config, test_data


### PR DESCRIPTION
## Summary
- implement `preprocessing/uda_dataloader.py` for loading domain text files
- extend `fedd3_main.py` and `baselines_main.py` to support unsupervised domain adaptation
- add command line arguments `--domain-dir` and `--target-domain`

## Testing
- `python -m py_compile preprocessing/uda_dataloader.py fedd3_main.py baselines_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6864953ce2f48323947a6bd2dff61f66